### PR TITLE
chore: k3s 헬스체크를 위한 liveness/readiness 프로브 활성화

### DIFF
--- a/src/main/kotlin/kr/io/team/loop/common/config/SecurityConfig.kt
+++ b/src/main/kotlin/kr/io/team/loop/common/config/SecurityConfig.kt
@@ -21,6 +21,7 @@ class SecurityConfig {
             authorizeHttpRequests {
                 authorize("/graphql", permitAll)
                 authorize("/h2-console/**", permitAll)
+                authorize("/actuator/health/**", permitAll)
                 authorize(anyRequest, authenticated)
             }
             headers {

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -10,3 +10,14 @@ spring:
 
     exposed:
         generate-ddl: false
+
+management:
+    endpoint:
+        health:
+            probes:
+                enabled: true
+    health:
+        livenessstate:
+            enabled: true
+        readinessstate:
+            enabled: true


### PR DESCRIPTION
## Summary
- Actuator health 프로브 엔드포인트(`/actuator/health/liveness`, `/actuator/health/readiness`) 활성화
- Security에서 `/actuator/health/**` 경로를 인증 없이 접근 허용

## 변경 파일
- `application.yml` — `management.endpoint.health.probes.enabled`, liveness/readiness state 활성화
- `SecurityConfig.kt` — `/actuator/health/**` permitAll 추가

## Test plan
- [x] 애플리케이션 기동 후 `/actuator/health/liveness` 200 응답 확인
- [x] `/actuator/health/readiness` 200 응답 확인
- [x] 기존 인증 필요 엔드포인트가 여전히 401 반환하는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)