### PR TITLE
feat: Task 제목 수정 Mutation 추가 (#21)

### DIFF
--- a/docs/plan/#21-task-title-update/checklist.md
+++ b/docs/plan/#21-task-title-update/checklist.md
@@ -9,3 +9,8 @@
 
 ## 선택 항목
 - [x] 소유권 검증 (본인 할일만 수정 가능)
+
+## PR 리뷰 반영
+- [x] updateTaskStatus + updateTaskTitle → updateTask 통합
+- [x] UpdateTaskInput에 title?, status? optional 필드
+- [x] 기존 updateTaskStatus 관련 코드 제거

--- a/docs/plan/#21-task-title-update/plan.md
+++ b/docs/plan/#21-task-title-update/plan.md
@@ -10,3 +10,12 @@
 - [x] 4단계: Infrastructure — ExposedTaskRepository.updateTitle 구현
 - [x] 5단계: Presentation — GraphQL 스키마 + DataFetcher 추가
 - [x] 6단계: DGS Codegen 빌드 및 전체 테스트 검증
+
+## PR 리뷰 반영 — updateTask 통합 리팩토링
+
+- [x] 7단계: Domain — TaskCommand.UpdateStatus + UpdateTitle → Update 통합
+- [x] 8단계: Domain — TaskRepository.updateStatus + updateTitle → update 통합
+- [x] 9단계: Application — TaskService TDD (기존 테스트 수정 + 새 케이스)
+- [x] 10단계: Infrastructure — ExposedTaskRepository.update 통합 구현
+- [x] 11단계: Presentation — GraphQL 스키마 updateTask 통합 + DataFetcher 수정
+- [x] 12단계: DGS Codegen 빌드 및 전체 테스트 검증

--- a/src/main/kotlin/kr/io/team/loop/task/application/service/TaskService.kt
+++ b/src/main/kotlin/kr/io/team/loop/task/application/service/TaskService.kt
@@ -21,8 +21,8 @@ class TaskService(
     fun findAll(query: TaskQuery): List<Task> = taskRepository.findAll(query)
 
     @Transactional
-    fun updateStatus(
-        command: TaskCommand.UpdateStatus,
+    fun update(
+        command: TaskCommand.Update,
         memberId: MemberId,
     ): Task {
         val task =
@@ -31,21 +31,7 @@ class TaskService(
         if (!task.isOwnedBy(memberId)) {
             throw AccessDeniedException("Task does not belong to member: ${memberId.value}")
         }
-        return taskRepository.updateStatus(command)
-    }
-
-    @Transactional
-    fun updateTitle(
-        command: TaskCommand.UpdateTitle,
-        memberId: MemberId,
-    ): Task {
-        val task =
-            taskRepository.findById(command.taskId)
-                ?: throw EntityNotFoundException("Task not found: ${command.taskId.value}")
-        if (!task.isOwnedBy(memberId)) {
-            throw AccessDeniedException("Task does not belong to member: ${memberId.value}")
-        }
-        return taskRepository.updateTitle(command)
+        return taskRepository.update(command)
     }
 
     @Transactional

--- a/src/main/kotlin/kr/io/team/loop/task/domain/model/TaskCommand.kt
+++ b/src/main/kotlin/kr/io/team/loop/task/domain/model/TaskCommand.kt
@@ -13,14 +13,10 @@ sealed interface TaskCommand {
         val taskDate: LocalDate,
     ) : TaskCommand
 
-    data class UpdateStatus(
+    data class Update(
         val taskId: TaskId,
-        val status: TaskStatus,
-    ) : TaskCommand
-
-    data class UpdateTitle(
-        val taskId: TaskId,
-        val title: TaskTitle,
+        val title: TaskTitle? = null,
+        val status: TaskStatus? = null,
     ) : TaskCommand
 
     data class Delete(

--- a/src/main/kotlin/kr/io/team/loop/task/domain/repository/TaskRepository.kt
+++ b/src/main/kotlin/kr/io/team/loop/task/domain/repository/TaskRepository.kt
@@ -8,9 +8,7 @@ import kr.io.team.loop.task.domain.model.TaskQuery
 interface TaskRepository {
     fun save(command: TaskCommand.Create): Task
 
-    fun updateStatus(command: TaskCommand.UpdateStatus): Task
-
-    fun updateTitle(command: TaskCommand.UpdateTitle): Task
+    fun update(command: TaskCommand.Update): Task
 
     fun delete(command: TaskCommand.Delete)
 

--- a/src/main/kotlin/kr/io/team/loop/task/infrastructure/persistence/ExposedTaskRepository.kt
+++ b/src/main/kotlin/kr/io/team/loop/task/infrastructure/persistence/ExposedTaskRepository.kt
@@ -48,19 +48,11 @@ class ExposedTaskRepository : TaskRepository {
         )
     }
 
-    override fun updateStatus(command: TaskCommand.UpdateStatus): Task {
+    override fun update(command: TaskCommand.Update): Task {
         val now = OffsetDateTime.now()
         TaskTable.update({ TaskTable.taskId eq command.taskId.value }) {
-            it[status] = command.status.name
-            it[updatedAt] = now
-        }
-        return findById(command.taskId)!!
-    }
-
-    override fun updateTitle(command: TaskCommand.UpdateTitle): Task {
-        val now = OffsetDateTime.now()
-        TaskTable.update({ TaskTable.taskId eq command.taskId.value }) {
-            it[title] = command.title.value
+            command.title?.let { newTitle -> it[title] = newTitle.value }
+            command.status?.let { newStatus -> it[status] = newStatus.name }
             it[updatedAt] = now
         }
         return findById(command.taskId)!!

--- a/src/main/kotlin/kr/io/team/loop/task/presentation/datafetcher/TaskDataFetcher.kt
+++ b/src/main/kotlin/kr/io/team/loop/task/presentation/datafetcher/TaskDataFetcher.kt
@@ -7,8 +7,7 @@ import com.netflix.graphql.dgs.InputArgument
 import kotlinx.datetime.LocalDate
 import kr.io.team.loop.codegen.types.CreateTaskInput
 import kr.io.team.loop.codegen.types.TaskFilter
-import kr.io.team.loop.codegen.types.UpdateTaskStatusInput
-import kr.io.team.loop.codegen.types.UpdateTaskTitleInput
+import kr.io.team.loop.codegen.types.UpdateTaskInput
 import kr.io.team.loop.common.config.Authorize
 import kr.io.team.loop.common.domain.GoalId
 import kr.io.team.loop.common.domain.MemberId
@@ -57,29 +56,17 @@ class TaskDataFetcher(
     }
 
     @DgsMutation
-    fun updateTaskStatus(
-        @InputArgument input: UpdateTaskStatusInput,
+    fun updateTask(
+        @InputArgument input: UpdateTaskInput,
         @Authorize memberId: Long,
     ): TaskGraphql {
         val command =
-            TaskCommand.UpdateStatus(
+            TaskCommand.Update(
                 taskId = TaskId(input.id.toLong()),
-                status = TaskStatus.valueOf(input.status.name),
+                title = input.title?.let { TaskTitle(it) },
+                status = input.status?.let { TaskStatus.valueOf(it.name) },
             )
-        return taskService.updateStatus(command, MemberId(memberId)).toGraphql()
-    }
-
-    @DgsMutation
-    fun updateTaskTitle(
-        @InputArgument input: UpdateTaskTitleInput,
-        @Authorize memberId: Long,
-    ): TaskGraphql {
-        val command =
-            TaskCommand.UpdateTitle(
-                taskId = TaskId(input.id.toLong()),
-                title = TaskTitle(input.title),
-            )
-        return taskService.updateTitle(command, MemberId(memberId)).toGraphql()
+        return taskService.update(command, MemberId(memberId)).toGraphql()
     }
 
     @DgsMutation

--- a/src/main/resources/schema/task.graphqls
+++ b/src/main/resources/schema/task.graphqls
@@ -13,16 +13,10 @@ extend type Mutation {
         input: CreateTaskInput!
     ): Task!
 
-    "할일의 완료/미완료 상태를 변경한다. (본인 할일만)"
-    updateTaskStatus(
-        "상태 변경 정보"
-        input: UpdateTaskStatusInput!
-    ): Task!
-
-    "할일의 제목을 수정한다. (본인 할일만)"
-    updateTaskTitle(
-        "제목 수정 정보"
-        input: UpdateTaskTitleInput!
+    "할일을 수정한다. 제목, 상태 등 변경할 필드만 전달한다. (본인 할일만)"
+    updateTask(
+        "수정할 할일 정보"
+        input: UpdateTaskInput!
     ): Task!
 
     "할일을 삭제한다. (본인 할일만)"
@@ -78,18 +72,12 @@ input CreateTaskInput {
     date: String!
 }
 
-"""할일 상태 변경 입력"""
-input UpdateTaskStatusInput {
-    "변경할 할일 ID"
-    id: ID!
-    "변경할 상태"
-    status: TaskStatus!
-}
-
-"""할일 제목 수정 입력"""
-input UpdateTaskTitleInput {
+"""할일 수정 입력. 변경할 필드만 전달한다."""
+input UpdateTaskInput {
     "수정할 할일 ID"
     id: ID!
-    "새 제목 (1~200자)"
-    title: String!
+    "새 제목 (1~200자, 선택)"
+    title: String
+    "새 상태 (선택)"
+    status: TaskStatus
 }

--- a/src/test/kotlin/kr/io/team/loop/task/application/service/TaskServiceTest.kt
+++ b/src/test/kotlin/kr/io/team/loop/task/application/service/TaskServiceTest.kt
@@ -91,78 +91,70 @@ class TaskServiceTest :
             }
         }
 
-        Given("할일 상태 변경 시") {
-            When("본인 할일이면") {
+        Given("할일 수정 시") {
+            When("본인 할일의 상태를 변경하면") {
                 val updatedTask = savedTask.copy(status = TaskStatus.DONE, updatedAt = Instant.now())
-                val command = TaskCommand.UpdateStatus(taskId = TaskId(1L), status = TaskStatus.DONE)
+                val command = TaskCommand.Update(taskId = TaskId(1L), status = TaskStatus.DONE)
 
                 every { taskRepository.findById(TaskId(1L)) } returns savedTask
-                every { taskRepository.updateStatus(command) } returns updatedTask
+                every { taskRepository.update(command) } returns updatedTask
 
-                val result = taskService.updateStatus(command, memberId)
+                val result = taskService.update(command, memberId)
 
                 Then("변경된 할일을 반환한다") {
                     result.status shouldBe TaskStatus.DONE
                 }
             }
 
-            When("존재하지 않는 할일이면") {
-                val command = TaskCommand.UpdateStatus(taskId = TaskId(99L), status = TaskStatus.DONE)
-                every { taskRepository.findById(TaskId(99L)) } returns null
-
-                Then("EntityNotFoundException이 발생한다") {
-                    shouldThrow<EntityNotFoundException> {
-                        taskService.updateStatus(command, memberId)
-                    }
-                }
-            }
-
-            When("본인 할일이 아니면") {
-                val command = TaskCommand.UpdateStatus(taskId = TaskId(1L), status = TaskStatus.DONE)
-                every { taskRepository.findById(TaskId(1L)) } returns savedTask
-
-                Then("AccessDeniedException이 발생한다") {
-                    shouldThrow<AccessDeniedException> {
-                        taskService.updateStatus(command, otherMemberId)
-                    }
-                }
-            }
-        }
-
-        Given("할일 제목 수정 시") {
-            When("본인 할일이면") {
+            When("본인 할일의 제목을 수정하면") {
                 val newTitle = TaskTitle("수학 문제 풀기")
                 val updatedTask = savedTask.copy(title = newTitle, updatedAt = Instant.now())
-                val command = TaskCommand.UpdateTitle(taskId = TaskId(1L), title = newTitle)
+                val command = TaskCommand.Update(taskId = TaskId(1L), title = newTitle)
 
                 every { taskRepository.findById(TaskId(1L)) } returns savedTask
-                every { taskRepository.updateTitle(command) } returns updatedTask
+                every { taskRepository.update(command) } returns updatedTask
 
-                val result = taskService.updateTitle(command, memberId)
+                val result = taskService.update(command, memberId)
 
                 Then("수정된 할일을 반환한다") {
                     result.title.value shouldBe "수학 문제 풀기"
                 }
             }
 
+            When("제목과 상태를 동시에 수정하면") {
+                val newTitle = TaskTitle("수학 문제 풀기")
+                val updatedTask = savedTask.copy(title = newTitle, status = TaskStatus.DONE, updatedAt = Instant.now())
+                val command = TaskCommand.Update(taskId = TaskId(1L), title = newTitle, status = TaskStatus.DONE)
+
+                every { taskRepository.findById(TaskId(1L)) } returns savedTask
+                every { taskRepository.update(command) } returns updatedTask
+
+                val result = taskService.update(command, memberId)
+
+                Then("수정된 할일을 반환한다") {
+                    result.title.value shouldBe "수학 문제 풀기"
+                    result.status shouldBe TaskStatus.DONE
+                }
+            }
+
             When("존재하지 않는 할일이면") {
-                val command = TaskCommand.UpdateTitle(taskId = TaskId(99L), title = TaskTitle("새 제목"))
+                val command = TaskCommand.Update(taskId = TaskId(99L), status = TaskStatus.DONE)
                 every { taskRepository.findById(TaskId(99L)) } returns null
 
                 Then("EntityNotFoundException이 발생한다") {
                     shouldThrow<EntityNotFoundException> {
-                        taskService.updateTitle(command, memberId)
+                        taskService.update(command, memberId)
                     }
                 }
             }
 
             When("본인 할일이 아니면") {
-                val command = TaskCommand.UpdateTitle(taskId = TaskId(1L), title = TaskTitle("새 제목"))
+                val command = TaskCommand.Update(taskId = TaskId(1L), status = TaskStatus.DONE)
                 every { taskRepository.findById(TaskId(1L)) } returns savedTask
 
                 Then("AccessDeniedException이 발생한다") {
                     shouldThrow<AccessDeniedException> {
-                        taskService.updateTitle(command, otherMemberId)
+                        taskService.update(command, otherMemberId)
                     }
                 }
             }


### PR DESCRIPTION
## Summary
- Task 제목을 수정할 수 있는 `updateTaskTitle` GraphQL Mutation 추가
- 본인 소유 할일만 수정 가능 (소유권 검증)
- `updateStatus`와 동일한 패턴으로 전 레이어(Domain → Application → Infrastructure → Presentation) 구현

## 변경 사항
- **Domain**: `TaskCommand.UpdateTitle`, `TaskRepository.updateTitle()` 추가
- **Application**: `TaskService.updateTitle()` — 소유권 검증 + 제목 수정
- **Infrastructure**: `ExposedTaskRepository.updateTitle()` 구현
- **Presentation**: `updateTaskTitle` mutation + `UpdateTaskTitleInput` input 스키마 추가
- **Test**: TaskServiceTest에 3개 테스트 케이스 추가 (성공, 미존재, 권한 없음)

## Test plan
- [x] TaskServiceTest — 본인 할일 제목 수정 성공
- [x] TaskServiceTest — 존재하지 않는 할일 → EntityNotFoundException
- [x] TaskServiceTest — 타인 할일 → AccessDeniedException
- [x] 전체 테스트 통과 (`./gradlew test`)

Closes #21

🤖 Generated with [Claude Code](https://claude.com/claude-code)