### PR TITLE
refactor: TaskId를 common에서 task BC로 이동 (#27)

### DIFF
--- a/docs/layers/domain.md
+++ b/docs/layers/domain.md
@@ -21,7 +21,7 @@ value class TaskTitle(val value: String) {
 }
 ```
 
-BC간 공유 VO(MemberId, TaskId 등)는 `common/domain/`에 위치합니다.
+BC간 공유 VO(MemberId, GoalId 등)는 `common/domain/`에 위치합니다.
 
 ### Command
 

--- a/docs/plan/#27-taskid-location-fix/checklist.md
+++ b/docs/plan/#27-taskid-location-fix/checklist.md
@@ -1,0 +1,10 @@
+# TaskId 위치 수정 검증 체크리스트
+
+## 필수 항목
+- [x] 아키텍처 원칙 준수 (common/domain에는 2개 이상 BC에서 사용하는 VO만 배치)
+- [x] 레이어 의존성 규칙 위반 없음
+- [x] 모든 테스트 통과
+- [x] 기존 테스트 깨지지 않음
+- [x] common/domain/TaskId.kt 삭제됨
+- [x] task/domain/model/TaskId.kt 생성됨
+- [x] 모든 import 경로 변경됨

--- a/docs/plan/#27-taskid-location-fix/plan.md
+++ b/docs/plan/#27-taskid-location-fix/plan.md
@@ -1,0 +1,11 @@
+# TaskId 위치 수정 계획
+
+> Issue: #27
+
+## 단계
+
+- [x] 1단계: TaskId를 task/domain/model/로 이동
+- [x] 2단계: common/domain/TaskId.kt 삭제
+- [x] 3단계: 모든 import 경로를 task.domain.model.TaskId로 변경
+- [x] 4단계: domain.md 문서에서 TaskId 공유 VO 언급 제거
+- [x] 5단계: 테스트 통과 확인

--- a/src/main/kotlin/kr/io/team/loop/task/domain/model/Task.kt
+++ b/src/main/kotlin/kr/io/team/loop/task/domain/model/Task.kt
@@ -3,7 +3,6 @@ package kr.io.team.loop.task.domain.model
 import kotlinx.datetime.LocalDate
 import kr.io.team.loop.common.domain.GoalId
 import kr.io.team.loop.common.domain.MemberId
-import kr.io.team.loop.common.domain.TaskId
 import java.time.Instant
 
 data class Task(

--- a/src/main/kotlin/kr/io/team/loop/task/domain/model/TaskCommand.kt
+++ b/src/main/kotlin/kr/io/team/loop/task/domain/model/TaskCommand.kt
@@ -3,7 +3,6 @@ package kr.io.team.loop.task.domain.model
 import kotlinx.datetime.LocalDate
 import kr.io.team.loop.common.domain.GoalId
 import kr.io.team.loop.common.domain.MemberId
-import kr.io.team.loop.common.domain.TaskId
 
 sealed interface TaskCommand {
     data class Create(

--- a/src/main/kotlin/kr/io/team/loop/task/domain/model/TaskId.kt
+++ b/src/main/kotlin/kr/io/team/loop/task/domain/model/TaskId.kt
@@ -1,4 +1,4 @@
-package kr.io.team.loop.common.domain
+package kr.io.team.loop.task.domain.model
 
 import kr.io.team.loop.common.domain.exception.InvalidInputException
 

--- a/src/main/kotlin/kr/io/team/loop/task/domain/repository/TaskRepository.kt
+++ b/src/main/kotlin/kr/io/team/loop/task/domain/repository/TaskRepository.kt
@@ -1,9 +1,9 @@
 package kr.io.team.loop.task.domain.repository
 
 import kr.io.team.loop.common.domain.GoalId
-import kr.io.team.loop.common.domain.TaskId
 import kr.io.team.loop.task.domain.model.Task
 import kr.io.team.loop.task.domain.model.TaskCommand
+import kr.io.team.loop.task.domain.model.TaskId
 import kr.io.team.loop.task.domain.model.TaskQuery
 
 interface TaskRepository {

--- a/src/main/kotlin/kr/io/team/loop/task/infrastructure/persistence/ExposedTaskRepository.kt
+++ b/src/main/kotlin/kr/io/team/loop/task/infrastructure/persistence/ExposedTaskRepository.kt
@@ -2,9 +2,9 @@ package kr.io.team.loop.task.infrastructure.persistence
 
 import kr.io.team.loop.common.domain.GoalId
 import kr.io.team.loop.common.domain.MemberId
-import kr.io.team.loop.common.domain.TaskId
 import kr.io.team.loop.task.domain.model.Task
 import kr.io.team.loop.task.domain.model.TaskCommand
+import kr.io.team.loop.task.domain.model.TaskId
 import kr.io.team.loop.task.domain.model.TaskQuery
 import kr.io.team.loop.task.domain.model.TaskStatus
 import kr.io.team.loop.task.domain.model.TaskTitle

--- a/src/main/kotlin/kr/io/team/loop/task/presentation/datafetcher/TaskDataFetcher.kt
+++ b/src/main/kotlin/kr/io/team/loop/task/presentation/datafetcher/TaskDataFetcher.kt
@@ -11,10 +11,10 @@ import kr.io.team.loop.codegen.types.UpdateTaskInput
 import kr.io.team.loop.common.config.Authorize
 import kr.io.team.loop.common.domain.GoalId
 import kr.io.team.loop.common.domain.MemberId
-import kr.io.team.loop.common.domain.TaskId
 import kr.io.team.loop.task.application.service.TaskService
 import kr.io.team.loop.task.domain.model.Task
 import kr.io.team.loop.task.domain.model.TaskCommand
+import kr.io.team.loop.task.domain.model.TaskId
 import kr.io.team.loop.task.domain.model.TaskQuery
 import kr.io.team.loop.task.domain.model.TaskStatus
 import kr.io.team.loop.task.domain.model.TaskTitle

--- a/src/test/kotlin/kr/io/team/loop/task/application/service/TaskServiceTest.kt
+++ b/src/test/kotlin/kr/io/team/loop/task/application/service/TaskServiceTest.kt
@@ -11,11 +11,11 @@ import io.mockk.verify
 import kotlinx.datetime.LocalDate
 import kr.io.team.loop.common.domain.GoalId
 import kr.io.team.loop.common.domain.MemberId
-import kr.io.team.loop.common.domain.TaskId
 import kr.io.team.loop.common.domain.exception.AccessDeniedException
 import kr.io.team.loop.common.domain.exception.EntityNotFoundException
 import kr.io.team.loop.task.domain.model.Task
 import kr.io.team.loop.task.domain.model.TaskCommand
+import kr.io.team.loop.task.domain.model.TaskId
 import kr.io.team.loop.task.domain.model.TaskQuery
 import kr.io.team.loop.task.domain.model.TaskStatus
 import kr.io.team.loop.task.domain.model.TaskTitle

--- a/src/test/kotlin/kr/io/team/loop/task/domain/model/TaskTest.kt
+++ b/src/test/kotlin/kr/io/team/loop/task/domain/model/TaskTest.kt
@@ -5,7 +5,7 @@ import io.kotest.matchers.shouldBe
 import kotlinx.datetime.LocalDate
 import kr.io.team.loop.common.domain.GoalId
 import kr.io.team.loop.common.domain.MemberId
-import kr.io.team.loop.common.domain.TaskId
+import kr.io.team.loop.task.domain.model.TaskId
 import java.time.Instant
 
 class TaskTest :


### PR DESCRIPTION
## Summary
- `TaskId` VO를 `common/domain/`에서 `task/domain/model/`로 이동
- task BC에서만 사용되는 VO가 common에 위치하여 "2개 이상 BC 사용" 규칙에 위반되던 문제 수정
- 모든 import 경로 변경 및 `docs/layers/domain.md` 예시 업데이트

## Test plan
- [x] 모든 기존 테스트 통과 확인 (`./gradlew test` BUILD SUCCESSFUL)
- [x] TaskId import가 `task.domain.model.TaskId`로 정상 변경 확인

Closes #27

🤖 Generated with [Claude Code](https://claude.com/claude-code)