### PR TITLE
chore: Prometheus 메트릭 엔드포인트 노출 설정

### DIFF
--- a/src/main/kotlin/kr/io/team/loop/common/config/SecurityConfig.kt
+++ b/src/main/kotlin/kr/io/team/loop/common/config/SecurityConfig.kt
@@ -26,6 +26,7 @@ class SecurityConfig {
                 authorize("/graphql", permitAll)
                 authorize("/h2-console/**", permitAll)
                 authorize("/actuator/health/**", permitAll)
+                authorize("/actuator/prometheus", permitAll)
                 authorize(anyRequest, authenticated)
             }
             headers {

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -12,6 +12,10 @@ spring:
         generate-ddl: false
 
 management:
+    endpoints:
+        web:
+            exposure:
+                include: health, prometheus
     endpoint:
         health:
             probes:


### PR DESCRIPTION
## Summary
- `application.yml`에 `management.endpoints.web.exposure.include: health, prometheus` 추가
- `SecurityConfig.kt`에 `/actuator/prometheus` permitAll 추가
- 보안은 k3s 인그레스 레벨에서 제어

Closes #34

## Test plan
- [x] 전체 빌드 및 테스트 통과 확인
- [x] `/actuator/prometheus` 엔드포인트 접근 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)